### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ The currently implemented functions are listed together with a short description
 https://github.com/roopeshvaddepally/python-ebay/wiki/List-of-eBay-APIs
 
 Extensive documentation of eBay's API is available on eBay's developer website. 
-This documentation focusses on XML messages that are sent to eBay's servers, 
+This documentation focuses on XML messages that are sent to eBay's servers, 
 and XML responses that are received from those servers.
 http://developer.ebay.com/products/overview
 

--- a/examples/example_alternative_config.py
+++ b/examples/example_alternative_config.py
@@ -1,5 +1,5 @@
 """
-Show haow to use alternative configuration files.
+Show how to use alternative configuration files.
 """
 from os import system
 from os.path import join, dirname, abspath


### PR DESCRIPTION
There are small typos in:
- README.rst
- examples/example_alternative_config.py

Fixes:
- Should read `how` rather than `haow`.
- Should read `focuses` rather than `focusses`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md